### PR TITLE
fix: display input next to the button on mobile

### DIFF
--- a/src/screens/Home/InputCard/InputCard.tsx
+++ b/src/screens/Home/InputCard/InputCard.tsx
@@ -6,16 +6,16 @@ function HomeInputCard({ title, onClick, buttonLabel }: any) {
       <h2 className="mb-4 uppercase tracking-wide font-semibold text-gray-800">
         {title}
       </h2>
-      <div>
+      <div className="flex">
         <input
-          className="py-2 px-4 rounded-l border-2 bg-gray-100 border-gray-500 text-gray-700 focus:bg-white focus:outline-none focus:border-black"
+          className="py-2 px-4 border-2 bg-gray-100 rounded-l rounded-r-none border-gray-500 text-gray-700 focus:bg-white focus:outline-none focus:border-black"
           type="text"
           placeholder="new-room"
         />
         <button
           onClick={onClick}
           type="button"
-          className="py-2 px-6 w-24 border-2 border-black bg-black rounded-r font-bold focus:outline-none hover:bg-gray-900 focus:shadow-outline"
+          className="py-2 px-6 w-24 border-2 rounded-l-none border-black rounded-r bg-black font-bold focus:outline-none hover:bg-gray-900 focus:shadow-outline"
         >
           {buttonLabel}
         </button>


### PR DESCRIPTION
**Summary**

Inputs on the Home page were breaking into two lines on mobile.

**Before**
<img width="359" alt="Screenshot 2019-11-20 at 22 48 56" src="https://user-images.githubusercontent.com/1817522/69281146-145a4580-0be8-11ea-8708-63d74295b4ba.png">

**After**
<img width="360" alt="Screenshot 2019-11-20 at 22 49 26" src="https://user-images.githubusercontent.com/1817522/69281159-1ae8bd00-0be8-11ea-858e-4b31f2d0b793.png">