### PR TITLE
Add custom logo and prevent collapsing of menu elements

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,6 +4,9 @@ import classnames from 'classnames';
 
 import HeaderLink from './Link';
 
+import logoSmall from '../../img/logo_small.svg';
+import logoBig from '../../img/logo_big.svg';
+
 function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const toggleMenu = () => setIsOpen(val => !val);
@@ -12,11 +15,12 @@ function Header() {
   return (
     <nav className="flex items-center justify-between flex-wrap">
       <div className="p-6 w-full lg:w-auto flex items-center justify-between flex-wrap">
-        <h1 className="text-gray-900 text-3xl">
+        <div>
           <Link to="/" onClick={closeMenu}>
-            ppoker
+            <img className="lg:hidden w-16" src={logoSmall} />
+            <img className="hidden w-32 lg:block" src={logoBig} />
           </Link>
-        </h1>
+        </div>
         <div className="block lg:hidden">
           <button
             type="button"

--- a/src/img/logo_big.svg
+++ b/src/img/logo_big.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 988 225" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-997.507,-2555.82)">
+        <g transform="matrix(4.91998,0,0,4.91998,-4431.82,-10504.5)">
+            <g transform="matrix(0.86,0,0,1,154.071,0)">
+                <text x="1100.51px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50.813px;fill:rgb(35,130,214);">P</text>
+            </g>
+            <text x="1117.29px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50px;">P</text>
+            <text x="1149.14px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50px;fill:rgb(255,8,141);">o</text>
+            <text x="1179.69px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50px;">ke</text>
+            <text x="1237.09px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50px;fill:rgb(35,214,150);">r</text>
+            <text x="1256.54px" y="2691.1px" style="font-family:'HelveticaNeue-Bold', 'Helvetica Neue';font-weight:700;font-size:50px;">{:}</text>
+        </g>
+    </g>
+</svg>

--- a/src/img/logo_small.svg
+++ b/src/img/logo_small.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1043 1043" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,1,-804.895,-1002.04)">
+        <g transform="matrix(0.238779,-1.14268,0.848516,0.177309,-315.016,2672.01)">
+            <path d="M1254.06,1189.18C1103.71,1189.18 981.826,1356.88 981.826,1563.75C981.826,1770.48 1103.81,1938.33 1254.06,1938.33C1404.4,1938.33 1526.28,1770.62 1526.28,1563.75L1254.06,1563.75L1254.06,1189.18Z" style="fill:rgb(246,246,246);stroke:rgb(255,8,141);stroke-width:18.24px;"/>
+        </g>
+        <g transform="matrix(0.929838,0,0,0.883707,54.2406,58.5649)">
+            <path d="M1367.95,1114.38L1884.17,1657.55L1367.95,2200.72L851.728,1657.55L1367.95,1114.38Z" style="fill:none;stroke:black;stroke-width:50.53px;stroke-linecap:square;stroke-linejoin:miter;"/>
+        </g>
+        <g transform="matrix(0.207492,0,0,1,943.821,-125.123)">
+            <path d="M1685.32,1442.17C1685.32,1415.53 1581.06,1393.9 1452.64,1393.9L987.29,1393.9C858.873,1393.9 754.614,1415.53 754.614,1442.17L754.614,2021.65C754.614,2048.3 858.873,2069.93 987.29,2069.93L1452.64,2069.93C1581.06,2069.93 1685.32,2048.3 1685.32,2021.65L1685.32,1442.17Z" style="fill:rgb(35,214,150);stroke:rgb(0,148,255);stroke-width:1.38px;"/>
+        </g>
+        <g transform="matrix(0.838119,0,0,0.796251,337.108,217.582)">
+            <ellipse cx="1227.43" cy="1392.84" rx="333.756" ry="325.192" style="fill:rgb(35,130,214);"/>
+        </g>
+        <g transform="matrix(1.0668e-16,1.71429,-1.40454,8.80909e-17,3274.19,-1159.21)">
+            <path d="M1545.76,1415.49C1555.43,1394.15 1560.52,1369.94 1560.52,1345.3C1560.52,1267.82 1511.16,1204.91 1450.35,1204.91C1389.55,1204.91 1340.18,1267.82 1340.18,1345.3C1340.18,1369.94 1345.28,1394.15 1354.94,1415.49L1545.76,1415.49Z" style="fill:rgb(35,214,150);stroke:rgb(0,148,255);stroke-width:29.25px;stroke-linecap:square;stroke-linejoin:miter;"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
This change adds a responsive custom logo and prevents menu icon to collapse if min width goes below tailwind's small band.

## Testing
Only manually tested. No unit tests were added to cover this change.

## Screen Shots

![Nov-20-2019 20-34-34](https://user-images.githubusercontent.com/545850/69304367-34ccd480-0bd5-11ea-8962-04c7cd882f67.gif)

<img width="1297" alt="Screen Shot 2019-11-20 at 8 35 48 PM" src="https://user-images.githubusercontent.com/545850/69304431-69409080-0bd5-11ea-9edb-b89651f22661.png">

<img width="492" alt="Screen Shot 2019-11-20 at 8 36 05 PM" src="https://user-images.githubusercontent.com/545850/69304432-6a71bd80-0bd5-11ea-997c-d34e1f90239c.png"> 

_This screen reflects the smallest width that the interface can be shrink now_
